### PR TITLE
Split bluetooth mainloop

### DIFF
--- a/publish-mqtt/src/main.rs
+++ b/publish-mqtt/src/main.rs
@@ -143,27 +143,6 @@ impl Sensor {
     }
 }
 
-async fn connect_start_sensor<'a>(
-    bt_session: &'a BluetoothSession,
-    homie: &mut HomieDevice,
-    properties: Vec<Property>,
-    sensor: &mut Sensor,
-) -> Result<(), Box<dyn Error>> {
-    let device = sensor.device(bt_session);
-    device.connect(CONNECT_TIMEOUT_MS)?;
-    start_notify_sensor(bt_session, &device)?;
-    homie
-        .add_node(Node::new(
-            sensor.node_id(),
-            sensor.name.to_string(),
-            "Mijia sensor".to_string(),
-            properties.to_vec(),
-        ))
-        .await?;
-    sensor.last_update_timestamp = Instant::now();
-    Ok(())
-}
-
 async fn requests(mut homie: HomieDevice) -> Result<(), Box<dyn Error>> {
     let sensor_names = hashmap_from_file(SENSOR_NAMES_FILENAME)?;
 
@@ -237,6 +216,27 @@ async fn requests(mut homie: HomieDevice) -> Result<(), Box<dyn Error>> {
         )
         .await?;
     }
+}
+
+async fn connect_start_sensor<'a>(
+    bt_session: &'a BluetoothSession,
+    homie: &mut HomieDevice,
+    properties: Vec<Property>,
+    sensor: &mut Sensor,
+) -> Result<(), Box<dyn Error>> {
+    let device = sensor.device(bt_session);
+    device.connect(CONNECT_TIMEOUT_MS)?;
+    start_notify_sensor(bt_session, &device)?;
+    homie
+        .add_node(Node::new(
+            sensor.node_id(),
+            sensor.name.to_string(),
+            "Mijia sensor".to_string(),
+            properties.to_vec(),
+        ))
+        .await?;
+    sensor.last_update_timestamp = Instant::now();
+    Ok(())
 }
 
 async fn service_bluetooth_event_queue(

--- a/publish-mqtt/src/main.rs
+++ b/publish-mqtt/src/main.rs
@@ -91,7 +91,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     let local = task::LocalSet::new();
 
     let bluetooth_handle = local.spawn_local(async move {
-        requests(homie).await.unwrap();
+        bluetooth_mainloop(homie).await.unwrap();
     });
 
     // Poll everything to completion, until the first one bombs out.
@@ -143,7 +143,7 @@ impl Sensor {
     }
 }
 
-async fn requests(mut homie: HomieDevice) -> Result<(), Box<dyn Error>> {
+async fn bluetooth_mainloop(mut homie: HomieDevice) -> Result<(), Box<dyn Error>> {
     let sensor_names = hashmap_from_file(SENSOR_NAMES_FILENAME)?;
 
     let bt_session = &BluetoothSession::create_session(None)?;

--- a/publish-mqtt/src/main.rs
+++ b/publish-mqtt/src/main.rs
@@ -229,73 +229,89 @@ async fn requests(mut homie: HomieDevice) -> Result<(), Box<dyn Error>> {
             sensors_to_connect.push_back(sensor);
         }
 
-        // Process events until there are none available for the timeout.
-        for event in bt_session
-            .incoming(INCOMING_TIMEOUT_MS)
-            .map(BluetoothEvent::from)
-        {
-            match event {
-                Some(BluetoothEvent::Value { object_path, value }) => {
-                    // TODO: Make this less hacky.
-                    let device_path = match object_path.strip_suffix(SERVICE_CHARACTERISTIC_PATH) {
-                        Some(path) => path,
-                        None => continue,
-                    };
-                    if let Some(sensor) = sensors_connected
-                        .iter_mut()
-                        .find(|s| s.device_path == device_path)
-                    {
-                        sensor.last_update_timestamp = Instant::now();
-                        if let Some(readings) = decode_value(&value) {
-                            println!("{} {} ({})", sensor.mac_address, readings, sensor.name);
-
-                            let node_id = sensor.node_id();
-                            homie
-                                .publish_value(
-                                    &node_id,
-                                    "temperature",
-                                    format!("{:.2}", readings.temperature),
-                                )
-                                .await?;
-                            homie
-                                .publish_value(&node_id, "humidity", readings.humidity)
-                                .await?;
-                            homie
-                                .publish_value(&node_id, "battery", readings.battery_percent)
-                                .await?;
-                        } else {
-                            println!("Invalid value from {}", sensor.name);
-                        }
-                    } else {
-                        // TODO: Still send it, in case it is useful?
-                        println!("Got update from unexpected device {}", device_path);
-                    }
-                }
-                Some(BluetoothEvent::Connected {
-                    object_path,
-                    connected: false,
-                }) => {
-                    if let Some(sensor_index) = sensors_connected
-                        .iter()
-                        .position(|s| s.device_path == object_path)
-                    {
-                        let sensor = sensors_connected.remove(sensor_index);
-                        println!("{} disconnected", sensor.name);
-                        homie.remove_node(&sensor.node_id()).await?;
-                        sensors_to_connect.push_back(sensor);
-                    } else {
-                        println!(
-                            "{} disconnected but wasn't known to be connected.",
-                            object_path
-                        );
-                    }
-                    continue;
-                }
-                _ => {
-                    log::trace!("{:?}", event);
-                    continue;
-                }
-            };
-        }
+        service_bluetooth_event_queue(
+            &bt_session,
+            &mut homie,
+            &mut sensors_connected,
+            &mut sensors_to_connect,
+        )
+        .await?;
     }
+}
+
+async fn service_bluetooth_event_queue(
+    bt_session: &BluetoothSession,
+    homie: &mut HomieDevice,
+    sensors_connected: &mut Vec<Sensor>,
+    sensors_to_connect: &mut VecDeque<Sensor>,
+) -> Result<(), Box<dyn Error>> {
+    // Process events until there are none available for the timeout.
+    for event in bt_session
+        .incoming(INCOMING_TIMEOUT_MS)
+        .map(BluetoothEvent::from)
+    {
+        match event {
+            Some(BluetoothEvent::Value { object_path, value }) => {
+                // TODO: Make this less hacky.
+                let device_path = match object_path.strip_suffix(SERVICE_CHARACTERISTIC_PATH) {
+                    Some(path) => path,
+                    None => continue,
+                };
+                if let Some(sensor) = sensors_connected
+                    .iter_mut()
+                    .find(|s| s.device_path == device_path)
+                {
+                    sensor.last_update_timestamp = Instant::now();
+                    if let Some(readings) = decode_value(&value) {
+                        println!("{} {} ({})", sensor.mac_address, readings, sensor.name);
+
+                        let node_id = sensor.node_id();
+                        homie
+                            .publish_value(
+                                &node_id,
+                                "temperature",
+                                format!("{:.2}", readings.temperature),
+                            )
+                            .await?;
+                        homie
+                            .publish_value(&node_id, "humidity", readings.humidity)
+                            .await?;
+                        homie
+                            .publish_value(&node_id, "battery", readings.battery_percent)
+                            .await?;
+                    } else {
+                        println!("Invalid value from {}", sensor.name);
+                    }
+                } else {
+                    // TODO: Still send it, in case it is useful?
+                    println!("Got update from unexpected device {}", device_path);
+                }
+            }
+            Some(BluetoothEvent::Connected {
+                object_path,
+                connected: false,
+            }) => {
+                if let Some(sensor_index) = sensors_connected
+                    .iter()
+                    .position(|s| s.device_path == object_path)
+                {
+                    let sensor = sensors_connected.remove(sensor_index);
+                    println!("{} disconnected", sensor.name);
+                    homie.remove_node(&sensor.node_id()).await?;
+                    sensors_to_connect.push_back(sensor);
+                } else {
+                    println!(
+                        "{} disconnected but wasn't known to be connected.",
+                        object_path
+                    );
+                }
+                continue;
+            }
+            _ => {
+                log::trace!("{:?}", event);
+                continue;
+            }
+        };
+    }
+    Ok(())
 }


### PR DESCRIPTION
This is intended to be a pure refactor.


Things that I have noticed while refactoring but not done (might happen in a separate PR):

- [ ] service_bluetooth_event_queue() should timeout after INCOMING_TIMEOUT_MS even if it has a steady stream of events
- [ ] handle_bluetooth_event() should probably check the sensors_to_connect queue if it gets a reading?
- [ ] add tests
- [ ] think of a better name for connect_start_sensor() or refactor it out of existence.