### PR TITLE
Implement disconnection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -555,8 +555,7 @@ dependencies = [
 [[package]]
 name = "mqtt4bytes"
 version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfde866d156cd232b3f68efe24dcc244438a80ceb5d5bee20f87ca3258a5c99f"
+source = "git+https://github.com/bytebeamio/rumqtt#e3ed5f8baf8fdda1f1e639e605474152b4080cc3"
 dependencies = [
  "bytes",
 ]
@@ -773,8 +772,7 @@ dependencies = [
 [[package]]
 name = "rumqttc"
 version = "0.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4f0f8a420173326a2e4634bd881df8166e985d5e6a2fe0ec37fda78027e0ee0"
+source = "git+https://github.com/bytebeamio/rumqtt#e3ed5f8baf8fdda1f1e639e605474152b4080cc3"
 dependencies = [
  "async-channel",
  "blocking",

--- a/homie/Cargo.toml
+++ b/homie/Cargo.toml
@@ -10,5 +10,5 @@ futures = "0.3"
 local_ipaddress = "0.1"
 log = "0.4"
 mac_address = "1.0"
-rumqttc = "0.0.6"
+rumqttc = { git = "https://github.com/bytebeamio/rumqtt" }
 tokio = "0.2.22"

--- a/homie/examples/lifecycle.rs
+++ b/homie/examples/lifecycle.rs
@@ -39,6 +39,9 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
         homie.ready().await?;
         println!("ready");
 
+        time::delay_for(Duration::from_secs(5)).await;
+        homie.disconnect().await?;
+        println!("disconnected");
         Ok(())
     });
 

--- a/homie/src/lib.rs
+++ b/homie/src/lib.rs
@@ -189,12 +189,12 @@ impl HomieDeviceBuilder {
 
     async fn build(self) -> (EventLoop, HomieDevice, HomieStats, HomieFirmware) {
         let mut mqtt_options = self.mqtt_options;
-        mqtt_options.set_last_will(LastWill {
-            topic: format!("{}/$state", self.device_base),
-            message: State::Lost.to_string(),
-            qos: QoS::AtLeastOnce,
-            retain: true,
-        });
+        mqtt_options.set_last_will(LastWill::new(
+            format!("{}/$state", self.device_base),
+            State::Lost,
+            QoS::AtLeastOnce,
+            true,
+        ));
         let event_loop = EventLoop::new(mqtt_options, REQUESTS_CAP).await;
 
         let publisher = DevicePublisher::new(event_loop.handle(), self.device_base);

--- a/publish-mqtt/Cargo.toml
+++ b/publish-mqtt/Cargo.toml
@@ -12,7 +12,7 @@ homie = { path = "../homie" }
 log = "0.4"
 mijia = { path = "../mijia" }
 pretty_env_logger = "0.4.0"
-rumqttc = "0.0.6"
+rumqttc = { git = "https://github.com/bytebeamio/rumqtt" }
 rustls = "0.17"
 rustls-native-certs = "0.3"
 tokio = "0.2.22"


### PR DESCRIPTION
This implements disconnection, which requires pulling in the latest version of rumqttc which fixes it. That also has an improvement to the interface for LastWill, which makes it take Into<Vec<u8>> list Publish, rather than a String.