### PR TITLE
unlock SensorState while connecting

### DIFF
--- a/publish-mqtt/src/main.rs
+++ b/publish-mqtt/src/main.rs
@@ -87,11 +87,13 @@ async fn main() -> Result<(), anyhow::Error> {
     Ok(())
 }
 
-#[derive(Debug)]
+#[derive(Debug, Copy, Clone)]
 enum ConnectionStatus {
     /// Not yet attempted to connect. Might already be connected from a previous
     /// run of this program.
     Unknown,
+    /// Currently connecting. Don't try again until the timeout expires.
+    Connecting { reserved_until: Instant },
     /// Connected, but could not subscribe to updates. GATT characteristics
     /// sometimes take a while to show up after connecting, so this retry is
     /// a bit of a work-around.
@@ -207,13 +209,6 @@ impl Sensor {
     }
 }
 
-#[derive(Debug)]
-struct SensorState {
-    sensors_to_connect: VecDeque<Sensor>,
-    sensors_connected: Vec<Sensor>,
-    homie: HomieDevice,
-}
-
 async fn run_sensor_system(
     mut homie: HomieDevice,
     bt_session: &MijiaSession,
@@ -226,6 +221,8 @@ async fn run_sensor_system(
         .with_context(|| std::line!().to_string())?;
 
     let state = Arc::new(Mutex::new(SensorState {
+        sensors: vec![],
+        next_idx: 0,
         sensors_to_connect: VecDeque::new(),
         sensors_connected: vec![],
         homie,
@@ -275,6 +272,60 @@ async fn bluetooth_connection_loop(
             .with_context(|| std::line!().to_string())?;
         }
         time::delay_for(CONNECT_INTERVAL).await;
+    }
+}
+
+#[derive(Debug)]
+struct SensorState {
+    sensors: Vec<Sensor>,
+    next_idx: usize,
+    sensors_to_connect: VecDeque<Sensor>,
+    sensors_connected: Vec<Sensor>,
+    homie: HomieDevice,
+}
+async fn action_next_sensor(
+    state: Arc<Mutex<SensorState>>,
+    bt_session: MijiaSession,
+) -> Result<(), anyhow::Error> {
+    let (idx, status) = match next_actionable_sensor(state).await {
+        Some(values) => values,
+        None => return Ok(()),
+    };
+    match status {
+        ConnectionStatus::Connecting { reserved_until } if reserved_until > Instant::now() => {
+            Ok(())
+        }
+        ConnectionStatus::Unknown
+        | ConnectionStatus::Connecting { .. }
+        | ConnectionStatus::SubscribingFailedOnce
+        | ConnectionStatus::Disconnected
+        | ConnectionStatus::MarkedDisconnected
+        | ConnectionStatus::WatchdogTimeOut => {
+            // connect_sensor_idx(state, bt_session, idx)
+            Ok(())
+        }
+        ConnectionStatus::Connected => {
+            // check_for_stale_sensor(state, bt_session, idx)
+            Ok(())
+        }
+    }
+}
+async fn next_actionable_sensor(
+    state: Arc<Mutex<SensorState>>,
+) -> Option<(usize, ConnectionStatus)> {
+    let mut state = state.lock().await;
+    let idx = state.next_idx;
+    let status = state.sensors.get(idx).map(|s| s.connection_status);
+
+    match status {
+        None => {
+            state.next_idx = 0;
+            None
+        }
+        Some(status) => {
+            state.next_idx += 1;
+            Some((idx, status))
+        }
     }
 }
 
@@ -355,6 +406,7 @@ async fn connect_start_sensor<'a>(
             // that we start again from a clean state next time.
             match sensor.connection_status {
                 ConnectionStatus::Unknown
+                | ConnectionStatus::Connecting { .. }
                 | ConnectionStatus::Disconnected
                 | ConnectionStatus::MarkedDisconnected
                 | ConnectionStatus::WatchdogTimeOut => {


### PR DESCRIPTION
Now that our libraries aren't locking our threads, we can start to do other things while we're connecting. This PR makes sure that we don't lock SensorState when we are connecting, so we can continue to receive updates from other sensors.